### PR TITLE
Remove feePayer as included account from Withdraw instruction

### DIFF
--- a/solana/operations/stake.go
+++ b/solana/operations/stake.go
@@ -63,7 +63,13 @@ func (x *StakeOperationMetadata) ToInstructions(opType string) []solPTypes.Instr
 		ins = append(ins, stakeprog.Deactivate(p(x.Stake), p(x.Staker)))
 		break
 	case solanago.Stake__WithdrawStake:
-		ins = addWithdrawStakeInsWithOptionalFeePayer(ins, x)
+		ins = append(ins,
+			stakeprog.Withdraw(
+				p(x.Stake),
+				p(x.Withdrawer),
+				p(x.WithdrawDestination),
+				x.Lamports,
+				p(x.LockupCustodian)))
 		break
 	case solanago.Stake__Merge:
 		ins = append(ins,
@@ -119,21 +125,4 @@ func addCreateStakeAccountIns(ins []solPTypes.Instruction, x *StakeOperationMeta
 
 func addDelegateStakeIns(ins []solPTypes.Instruction, x *StakeOperationMetadata) []solPTypes.Instruction {
 	return append(ins, stakeprog.DelegateStake(p(x.Stake), p(x.Staker), p(x.VoteAccount)))
-}
-
-func addWithdrawStakeInsWithOptionalFeePayer(ins []solPTypes.Instruction, x *StakeOperationMetadata) []solPTypes.Instruction {
-	withdrawIns := stakeprog.Withdraw(
-		p(x.Stake),
-		p(x.Withdrawer),
-		p(x.WithdrawDestination),
-		x.Lamports,
-		p(x.LockupCustodian))
-
-	feePayerPubkey := p(x.FeePayer)
-
-	if feePayerPubkey != (common.PublicKey{}) {
-		withdrawIns.Accounts = append(withdrawIns.Accounts, solPTypes.AccountMeta{PubKey: feePayerPubkey, IsSigner: true, IsWritable: false})
-	}
-
-	return append(ins, withdrawIns)
 }


### PR DESCRIPTION
Although the node accepts the transaction like this, there is no need to put the fee-payer into the withdraw instruction's account list. It will be included in the transaction's full account inputs list anyways, and will pay the fees.